### PR TITLE
Pacote `microtype` causa erro de compilação com abntex2

### DIFF
--- a/trabalho/trabalho-academico.tex
+++ b/trabalho/trabalho-academico.tex
@@ -39,7 +39,11 @@
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{lmodern}
-\usepackage{microtype} % para melhorias de justificação
+% The 'microtype' package may cause compilation errors with 
+% abntex2 in some environments.
+% This may get fixed at some point, so you may uncomment
+% this line and test it if you wish.
+% \usepackage{microtype} % para melhorias de justificação
 \usepackage{indentfirst}
 
 \renewcommand{\ABNTEXchapterfont}{\fontfamily{ptm}\fontseries{b}\selectfont}

--- a/versao_ingles/trabalho-academico.tex
+++ b/versao_ingles/trabalho-academico.tex
@@ -39,7 +39,11 @@
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{lmodern}
-\usepackage{microtype} % para melhorias de justificação
+% The 'microtype' package may cause compilation errors with 
+% abntex2 in some environments.
+% This may get fixed at some point, so you may uncomment
+% this line and test it if you wish.
+% \usepackage{microtype} % para melhorias de justificação
 \usepackage{indentfirst}
 \usepackage{csquotes}
 


### PR DESCRIPTION
Eu passei algumas horas tentando decifrar o que estava provocando o seguinte erro de compilação:

> ./.out/trabalho-academico.toc|13 error| Argument of \MakeUppercase (arg 1) has an extra }.
> trabalho-academico.tex|| Runaway argument?
> ./.out/trabalho-academico.toc|13 error| Paragraph ended before \MakeUppercase (arg 1) was complete.
> ./.out/trabalho-academico.toc|13 error| LaTeX Error: The key '__kernel/\MT@gobble@to@nil \MT@nil' is unknown and is being ignored.

E aparentemente o pacote `microtype` causa esse erro na versão mais nova do `abntex2`, devido ao uso do commando `\MakeUppercase` na formatação do sumário. Veja, por exemplo [esta issue no repositório do abntex 2](https://github.com/abntex/abntex2/issues/259) ou [esta issue no repositório do microtype](https://github.com/schlcht/microtype/issues/29).

Aparentemente, este é um erro que não acontece sempre, sendo que um usuário relatou que ele ocorre localmente, mas não no Overleaf.

Tendo em vista que não conseguir solucionar o problema pode desmotivar alguém menos versado em LaTeX a utilizar este (muito bem adaptado, aliás) template de TCC para a EMAp, acho que vale a pena deixar esse pacote comentado, com um aviso para quem pensar em usá-lo.